### PR TITLE
[rpm] Disable thumb compilation

### DIFF
--- a/rpm/valgrind.spec
+++ b/rpm/valgrind.spec
@@ -57,6 +57,9 @@ Requires: valgrind = %{version}-%{release}
 RPM_OPT_FLAGS="`echo " %{optflags} " | sed 's/ -m\(64\|3[21]\) / /g;s/ -fexceptions / /g;s/^ //;s/ $//' | \
     sed s/-Wp,-D_FORTIFY_SOURCE=2// | sed s/-D_FORTIFY_SOURCE=2//`"
 
+# valgrind's instruction compiler does not work on thumb hosts
+RPM_OPT_FLAGS="`echo " $RPM_OPT_FLAGS " | sed 's/ -mthumb / /g'`"
+
 export CFLAGS="$RPM_OPT_FLAGS"
 export CXXFLAGS="$RPM_OPT_FLAGS"
 autoreconf -fi


### PR DESCRIPTION
valgrind doesn't work with thumb hosts

I tried fixing a few of the problems but in the end decided it's better to just compile it in arm mode, since it obviously hasn't been tested on thumb either.

(Clarification: it handles thumb _guests_ just fine, this is about disabling the use of thumb mode in valgrind's own code, which contains a bunch of handcoded assembler)